### PR TITLE
feat: configurable storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ ReactDOM.render(
 - `onItemAdd`: Triggered on items added to your cart, unless the item already exists, then `onItemUpdate` will be invoked
 - `onItemUpdate`: Triggered on items updated in your cart, unless you are setting the quantity to `0`, then `onItemRemove` will be invoked
 - `onItemRemove`: Triggered on items removed from your cart
+- `storage`: Must return `[getter, setter]`
 
 ## `useCart`
 

--- a/src/index.js
+++ b/src/index.js
@@ -96,8 +96,9 @@ export function CartProvider({
   onItemAdd,
   onItemUpdate,
   onItemRemove,
+  storage = useLocalStorage,
 }) {
-  const [savedCart, saveCart] = useLocalStorage(
+  const [savedCart, saveCart] = storage(
     "react-use-cart",
     JSON.stringify({
       id,


### PR DESCRIPTION
Closes #31 

Storage can now be optional by providing a dummy `[getter, setter]`. The default remains as `localStorage` to prevent a breaking change.