### PR TITLE
feat: Allow adding free items to the cart

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ export function CartProvider({
 
     const currentItem = state.items.find((i) => i.id === item.id);
 
-    if (!currentItem && !item.price)
+    if (!currentItem && !item.hasOwnProperty("price"))
       throw new Error("You must pass a `price` for new items");
 
     if (!currentItem) {

--- a/index.test.js
+++ b/index.test.js
@@ -87,6 +87,29 @@ describe("addItem", () => {
     expect(result.current.items).toHaveLength(1);
     expect(result.current.totalItems).toBe(1);
     expect(result.current.totalUniqueItems).toBe(1);
+    expect(result.current.cartTotal).toBe(1000);
+    expect(result.current.isEmpty).toBe(false);
+  });
+
+  test("allows free item", () => {
+    const wrapper = ({ children }) => (
+      <CartProvider id="test">{children}</CartProvider>
+    );
+
+    const { result } = renderHook(() => useCart(), {
+      wrapper,
+    });
+
+    const item = { id: "test", price: 0 };
+
+    act(() => {
+      result.current.addItem(item);
+    });
+
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.totalItems).toBe(1);
+    expect(result.current.totalUniqueItems).toBe(1);
+    expect(result.current.cartTotal).toBe(0);
     expect(result.current.isEmpty).toBe(false);
   });
 


### PR DESCRIPTION
Changes the addItem method so that when you add a new item, when we check the price key, instead of checking when the price is non-truthy, we check if the key exists in the object.

This allows the addition of 0 value prices.