### PR TITLE
fix: Ensure lineTotal is recalculated when updating item quantity

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -337,6 +337,50 @@ describe("updateItemQuantity", () => {
 
     expect(called).toBe(true);
   });
+
+  test("recalculates itemTotal when incrementing item quantity", () => {
+    const item = { id: "test", price: 1000 };
+
+    const wrapper = ({ children }) => (
+      <CartProvider id="test">{children}</CartProvider>
+    );
+
+    const { result } = renderHook(() => useCart(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.addItem(item);
+    });
+
+    act(() => {
+      result.current.updateItemQuantity(item.id, 2);
+    });
+
+    expect(result.current.items[0].itemTotal).toBe(2000);
+  });
+
+  test("recalculates itemTotal when decrementing item quantity", () => {
+    const item = { id: "test", price: 1000, quantity: 2 };
+
+    const wrapper = ({ children }) => (
+      <CartProvider id="test">{children}</CartProvider>
+    );
+
+    const { result } = renderHook(() => useCart(), {
+      wrapper,
+    });
+
+    act(() => {
+      result.current.addItem(item);
+    });
+
+    act(() => {
+      result.current.updateItemQuantity(item.id, 1);
+    });
+
+    expect(result.current.items[0].itemTotal).toBe(1000);
+  });
 });
 
 describe("removeItem", () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -117,8 +117,8 @@ const generateCartState = (state = initialState, items: Item[]) => {
 
 const calculateItemTotals = (items: Item[]) =>
   items.map((item) => ({
-    itemTotal: item.price * item.quantity!,
     ...item,
+    itemTotal: item.price * item.quantity!,
   }));
 
 const calculateCartTotal = (items: Item[]) =>


### PR DESCRIPTION
Ensures `itemTotal` is recalculated when updating item quantity.

* Add tests to check `lineTotal` is recalculated when incrementing/decrementing item quantity
* Don't overwrite `itemTotal` key with spread operator