### PR TITLE
chore: Add test workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 12
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Build package
         run: npm run build
       - name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
           node-version: 12
       - name: Install dependencies
         run: npm install
-      - name: Test package
-        run: npm test
       - name: Build package
         run: npm run build
       - name: Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+on:
+  pull_request:
+    branches:
+      - main
+      - beta
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install dependencies
+        run: npm ci
+      - name: Build package
+        run: npm run build
+      - name: Run tests
+        run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,12 @@
-name: Test
+name: Build & Test
 on:
   pull_request:
     branches:
       - main
       - beta
 jobs:
-  test:
-    name: Test
+  build:
+    name: Build
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -19,5 +19,18 @@ jobs:
         run: npm ci
       - name: Build package
         run: npm run build
+  test:
+    name: Test
+    needs: build
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install dependencies
+        run: npm ci
       - name: Run tests
         run: npm run test


### PR DESCRIPTION
Adds a test workflow to run against PRs which base branch is `main` or `beta`.

Also prefers [`npm ci`](https://docs.npmjs.com/cli/v7/commands/npm-ci) for installing dependencies.

Fixes #63.