### PR TITLE
feat: export Item and Metadata interfaces

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import useLocalStorage from "./useLocalStorage";
 
-interface Item {
+export interface Item {
   id: string;
   price: number;
   quantity?: number;
@@ -20,7 +20,7 @@ interface InitialState {
   metadata?: Metadata;
 }
 
-interface Metadata {
+export interface Metadata {
   [key: string]: any;
 }
 


### PR DESCRIPTION
I found it useful to be able to access these interface so they  can be extended for custom cart item types. e.g. 
```
interface MyCartItem extends Item {
   color: string
}
```