### PR TITLE
feat: add methods to clear and set (instead of merge) metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,9 +314,41 @@ const { emptyCart } = useCart();
 emptyCart();
 ```
 
+### `clearCartMetadata()`
+
+The `clearCartMetadata()` will reset the `metadata` to an empty object.
+
+#### Usage
+
+```js
+import { useCart } from "react-use-cart";
+
+const { clearCartMetadata } = useCart();
+
+clearCartMetadata();
+```
+
+### `setCartMetadata(object)`
+
+The `setCartMetadata()` will replace the `metadata` object on the cart. You must pass it an object.
+
+#### Args
+
+- `object`: A object with key/value pairs. The key being a string.
+
+#### Usage
+
+```js
+import { useCart } from "react-use-cart";
+
+const { setCartMetadata } = useCart();
+
+setCartMetadata({ notes: "This is the only metadata" });
+```
+
 ### `updateCartMetadata(object)`
 
-The `updateCartMetadata()` will update the `metadata` object on the cart. You must pass it a object.
+The `updateCartMetadata()` will update the `metadata` object on the cart. You must pass it an object. This will merge the passed object with the existing metadata.
 
 #### Args
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,6 +33,8 @@ interface CartProviderState extends InitialState {
   emptyCart: () => void;
   getItem: (id: Item["id"]) => any | undefined;
   inCart: (id: Item["id"]) => boolean;
+  clearCartMetadata: () => void;
+  setCartMetadata: (metadata: Metadata) => void;
   updateCartMetadata: (metadata: Metadata) => void;
 }
 
@@ -46,6 +48,8 @@ export type Actions =
       payload: object;
     }
   | { type: "EMPTY_CART" }
+  | { type: "CLEAR_CART_META"}
+  | { type: "SET_CART_META"; payload: Metadata}
   | { type: "UPDATE_CART_META"; payload: Metadata };
 
 export const initialState: any = {
@@ -104,6 +108,20 @@ function reducer(state: CartProviderState, action: Actions) {
 
     case "EMPTY_CART":
       return initialState;
+
+    case "CLEAR_CART_META":
+      return {
+        ...state,
+        metadata: {}
+      };
+
+    case "SET_CART_META":
+      return {
+        ...state,
+        metadata: {
+          ...action.payload
+        }
+      };
 
     case "UPDATE_CART_META":
       return {
@@ -283,6 +301,21 @@ export const CartProvider: React.FC<{
 
   const inCart = (id: Item["id"]) => state.items.some((i: Item) => i.id === id);
 
+  const clearCartMetadata = () => {
+    dispatch({
+      type: "CLEAR_CART_META",
+    });
+  };
+
+  const setCartMetadata = (metadata: Metadata) => {
+    if (!metadata) return;
+
+    dispatch({
+      type: "SET_CART_META",
+      payload: metadata,
+    });
+  };
+
   const updateCartMetadata = (metadata: Metadata) => {
     if (!metadata) return;
 
@@ -304,6 +337,8 @@ export const CartProvider: React.FC<{
         updateItemQuantity,
         removeItem,
         emptyCart,
+        clearCartMetadata,
+        setCartMetadata,
         updateCartMetadata,
       }}
     >

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -410,6 +410,48 @@ describe("emptyCart", () => {
 });
 
 describe("updateCartMetadata", () => {
+  test("clears cart metadata", () => {
+    const {result} = renderHook(() => useCart(), {
+        wrapper: CartProvider,
+    });
+
+    const metadata = {
+        coupon: "abc123",
+        notes: "Leave on door step",
+    };
+
+    act(() => result.current.updateCartMetadata(metadata));
+
+    expect(result.current.metadata).toEqual(metadata);
+
+    act(() => result.current.clearCartMetadata());
+
+    expect(result.current.metadata).toEqual({});
+  });
+
+  test("sets cart metadata", () => {
+    const {result} = renderHook(() => useCart(), {
+        wrapper: CartProvider,
+    });
+
+    const metadata = {
+        coupon: "abc123",
+        notes: "Leave on door step",
+    };
+
+    act(() => result.current.updateCartMetadata(metadata));
+
+    expect(result.current.metadata).toEqual(metadata);
+
+    const replaceMetadata = {
+        delivery: "same-day"
+    }
+
+    act(() => result.current.setCartMetadata(replaceMetadata));
+
+    expect(result.current.metadata).toEqual(replaceMetadata);
+  });
+
   test("updates cart metadata", () => {
     const { result } = renderHook(() => useCart(), {
       wrapper: CartProvider,
@@ -453,7 +495,7 @@ describe("updateCartMetadata", () => {
 describe("setItems", () => {
   test("set cart items state", () => {
     const items = [{ id: "test", price: 1000 }, { id: "test2", price: 2000 }];
-    
+
     const wrapper: FC<Props> = ({ children }) => (
       <CartProvider defaultItems={[]}>{children}</CartProvider>
     );


### PR DESCRIPTION
This allows to easily manage cart metadata more granularly