### PR TITLE
feat: exporting interface InitialState and CartProviderState

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ export interface Item {
   [key: string]: any;
 }
 
-interface InitialState {
+export interface InitialState {
   id: string;
   items: Item[];
   isEmpty: boolean;
@@ -24,7 +24,7 @@ export interface Metadata {
   [key: string]: any;
 }
 
-interface CartProviderState extends InitialState {
+export interface CartProviderState extends InitialState {
   addItem: (item: Item, quantity?: number) => void;
   removeItem: (id: Item["id"]) => void;
   updateItem: (id: Item["id"], payload: object) => void;


### PR DESCRIPTION
I needed to use the interface `CartProviderState` and the alternative was something like `type ControlledCard = ReturnType<typeof useControlledCart>`. I guess it would be useful if exported.